### PR TITLE
Fix some broken video thumbnails.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,19 +9,19 @@ All contributions are **welcome**.
 
  - [**Introduction to Haskell (part 1)** - David Laing](https://vimeo.com/88540533)
 
-   [![Introduction to Haskell (part 1) - David Laing](https://i.vimeocdn.com/video/467059673.webp?mw=200&mh=150)](https://vimeo.com/88540533)
+   [![Introduction to Haskell (part 1) - David Laing](https://i.vimeocdn.com/video/467059673_200x150.jpg)](https://vimeo.com/88540533)
    
 - [**Introduction to Haskell (part 2)** - Nick Partridge](https://vimeo.com/90515452)
 
-   [![Introduction to Haskell (part 2) - Nick Partridge](https://i.vimeocdn.com/video/469701808.webp?mw=200&mh=150)](https://vimeo.com/90515452)
+   [![Introduction to Haskell (part 2) - Nick Partridge](https://i.vimeocdn.com/video/469701808_200x150.jpg)](https://vimeo.com/90515452)
    
 - [**Introduction to Haskell (part 3)** - Matthew Brecknell](https://vimeo.com/92976563)
 
-   [![Introduction to Haskell (part 3) - Matthew Brecknell](https://i.vimeocdn.com/video/472928030.webp?mw=200&mh=150)](https://vimeo.com/92976563)
+   [![Introduction to Haskell (part 3) - Matthew Brecknell](https://i.vimeocdn.com/video/472928030_200x150.jpg)](https://vimeo.com/92976563)
    
 - [**Functional Programming and Haskell** - Tim Dawborn and James Constab](https://vimeo.com/1920921)
 
-   [![Functional Programming and Haskell](https://i.vimeocdn.com/video/63189999.webp?mw=200&mh=150)](https://vimeo.com/1920921)
+   [![Functional Programming and Haskell](https://i.vimeocdn.com/video/63189999_200x150.jpg)](https://vimeo.com/1920921)
 
 - [**Functional Programming Fundamentals, Chapter 1 of 13** - Dr. Erik Meijer](http://channel9.msdn.com/Series/C9-Lectures-Erik-Meijer-Functional-Programming-Fundamentals/Lecture-Series-Erik-Meijer-Functional-Programming-Fundamentals-Chapter-1)
 
@@ -41,19 +41,19 @@ All contributions are **welcome**.
 
 - [**How Haskell is Changing my Brain** - Alissa Pajer](https://vimeo.com/96639840)
 
-   [![How Haskell is Changing my Brain](https://i.vimeocdn.com/video/476747540.webp?mw=200&mh=150)](https://vimeo.com/96639840)
+   [![How Haskell is Changing my Brain](https://i.vimeocdn.com/video/476747540_200x150.jpg)](https://vimeo.com/96639840)
 
 - [**Functional Programming News** - Nick Partridge](https://vimeo.com/88487290)
 
-   [![Functional Programming News](https://i.vimeocdn.com/video/466973691.webp?mw=200&mh=150)](https://vimeo.com/88487290)
+   [![Functional Programming News](https://i.vimeocdn.com/video/466973691_200x150.jpg)](https://vimeo.com/88487290)
    
-- [**Haskell ad social web** - Phillip Weaver](https://vimeo.com/21210266)
+- [**Haskell and the Social Web** - Phillip Weaver](https://vimeo.com/21210266)
 
-  [<img src="https://i.vimeocdn.com/video/147437664.webp?mw=960&mh=540" width="200px" height="140px" />](https://vimeo.com/21210266)
+  [<img src="http://i.vimeocdn.com/video/147437664_200x140.jpg" width="200px" height="140px" />](https://vimeo.com/21210266)
   
 - [**Don Stewart on Real World Haskell**](https://www.youtube.com/watch?v=4YfkwfZ7AV4)
 
-  [<img src="http://i.ytimg.com/vi_webp/4YfkwfZ7AV4/default.webp" width="200px" height="140px" />](https://www.youtube.com/watch?v=4YfkwfZ7AV4)
+  [<img src="http://i.ytimg.com/vi/4YfkwfZ7AV4/mqdefault.jpg" width="200px" height="140px" />](https://www.youtube.com/watch?v=4YfkwfZ7AV4)
   
 - [**Haskell Amuse-Bouche - Mark Lentczne**](https://www.youtube.com/watch?v=b9FagOVqxmI)
 
@@ -65,7 +65,7 @@ All contributions are **welcome**.
   
 - [**Functional Reactive Programming for Musical User Interface** - Paul Hudak](https://vimeo.com/96744621)
 
-  [<img src="https://i.vimeocdn.com/video/476988542.webp?mw=960&mh=540" width="200px" height="130px" />](https://vimeo.com/96744621)
+  [<img src="https://i.vimeocdn.com/video/476988542_200x130.jpg" width="200px" height="130px" />](https://vimeo.com/96744621)
   
 - [**Advanced Functional Programming - The Expression Problem** - Dr. Ralf Lämmel](http://channel9.msdn.com/Shows/Going+Deep/C9-Lectures-Dr-Ralf-Laemmel-Advanced-Functional-Programming-The-Expression-Problem)
 
@@ -73,7 +73,7 @@ All contributions are **welcome**.
   
 - [**Running startup on Haskell** - Bryan O'Sullivan](https://www.youtube.com/watch?v=ZR3Jirqk6W8)
 
-  [<img src="http://i.ytimg.com/vi_webp/ZR3Jirqk6W8/mqdefault.webp" width="200px" height="130px" />](https://www.youtube.com/watch?v=ZR3Jirqk6W8)
+  [<img src="http://i.ytimg.com/vi/ZR3Jirqk6W8/mqdefault.jpg" width="200px" height="130px" />](https://www.youtube.com/watch?v=ZR3Jirqk6W8)
 
 ## Workflow
 
@@ -85,7 +85,7 @@ All contributions are **welcome**.
 
 - [**Practical Data Processing With Haskell and Putting Cloud Haskell to Work** - Ozgun Ataman and Gershom Bazerman](https://vimeo.com/53906049)
 
-  [<img src="https://i.vimeocdn.com/video/372596445.webp?mw=960&mh=540" width="200px" height="130px" />](https://vimeo.com/53906049)
+  [<img src="https://i.vimeocdn.com/video/372596445_200x130.jpg" width="200px" height="130px" />](https://vimeo.com/53906049)
   
 - [**Adventure with Types in Haskell (Lecture 1)** - Simon Peyton Jones ](https://www.youtube.com/watch?v=6COvD8oynmI)
 
@@ -100,7 +100,7 @@ All contributions are **welcome**.
 
 - [**Types and Testing in Haskell** - Daniel Patterson](https://vimeo.com/112858645)
 
-  [<img src="https://i.vimeocdn.com/video/497977555.webp?mw=200&mh=140" width="200px" height="130px" />](https://vimeo.com/112858645)
+  [<img src="https://i.vimeocdn.com/video/497977555_200x130.jpg" width="200px" height="130px" />](https://vimeo.com/112858645)
 
 
 **Tip:** If you want to download all videos from this list, you can use command by [@jefdaj](http://www.reddit.com/user/jefdaj)


### PR DESCRIPTION
Switch some direct thumbnail image links to .jpg rather than .webp. .webp is not supported in IE, Firefox and Safari.
