### PR TITLE
Adds video on parsec

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ All contributions are **welcome**.
 
   [<img src="https://i.vimeocdn.com/video/469235326_150x84.jpg" width="200px" height="130px" />][hadoop]
 
+- [**Parsing Stuff in Haskell** - Ben Clifford][parsec]
+
+  [<img src="http://i.ytimg.com/vi/r_Enynu_TV0/default.jpg" width="200px" height="130px" />][parsec]
+
 ## Testing
 
 - [**Types and Testing in Haskell** - Daniel Patterson](https://vimeo.com/112858645)
@@ -126,6 +130,7 @@ Note that you need youtube-dl for correct work.
 [GHCJS]:http://vimeo.com/80895330
 [lenses]:http://vimeo.com/90184695
 [hadoop]:http://vimeo.com/90189610
+[parsec]:https://www.youtube.com/watch?v=r_Enynu_TV0
 
 
 


### PR DESCRIPTION
This video was done in 2013 for the London Haskell Users Group. It covers using Applicative, Control Monad, and Parsec to build a JSON parser. I found it to be a concise and accessible introduction to Parsec, so thought I'd submit a pull to add it to your list.
