### PR TITLE
Youtube-dl attempting to download gitter link and breaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ All contributions are **welcome**.
 
 **Tip:** If you want to download all videos from this list, you can use command by [@jefdaj](http://www.reddit.com/user/jefdaj)
 ```bash
-curl https://raw.githubusercontent.com/drKraken/haskell-must-watch/master/README.md |
+curl https://raw.githubusercontent.com/drKraken/haskell-must-watch/master/README.md | tail -n +5
 grep -Po '\(https?://(.*)\)' | tr -d '()' |
 xargs youtube-dl
 ```


### PR DESCRIPTION
Removed the first 5 lines with tail so that youtube-dl doesn't attempt to download the gitter link. The fact that it's 5 lines was a little bit of an arbitrary decision.

`tail` works on both gnu and bsd so that should cover a majority of users.
